### PR TITLE
Fix PHP 7 only coalesce syntax

### DIFF
--- a/slack.php
+++ b/slack.php
@@ -105,7 +105,7 @@ task('deploy:slack', function () {
         '{{stage}}'        => $stage,
         '{{user}}'         => $user,
         '{{branch}}'       => $branch,
-        '{{app_name}}'     => $config['app'] ?? 'app-name',
+        '{{app_name}}'     => isset($config['app']) ? $config['app'] : 'app-name',
     ];
     $config['message'] = strtr($config['message'], $messagePlaceHolders);
 


### PR DESCRIPTION
Due to a recent support for PHP 5.6 broke. This commit reverts the change.